### PR TITLE
docs: add project overview and agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# Agent Instruction File
+
+## 🎮 Project Overview
+This repository contains the source code and assets for a **comic strip-style, choose-your-own-adventure video game**. The game uses **Godot 4.x** as the engine and is written primarily in **GDScript**, with external narrative files defined in **JSON** format.
+
+The goal is to create a visually engaging story-driven experience where the player makes decisions that affect the branching narrative. Comic panels, speech bubbles, and illustrated scenes form the core presentation.
+
+---
+
+## 🧠 Agent Goals
+You are an LLM (e.g., OpenAI Codex) assisting with:
+- Writing and updating GDScript for the Godot engine.
+- Managing external narrative files (JSON).
+- Automating repetitive scripting tasks (e.g., new scene templates).
+- Assisting with bug fixes, refactoring, and documentation.
+- Helping designers write and test narrative content in structured formats.
+
+---
+
+## 🔧 Coding Instructions
+
+### 1. Game Architecture
+- The game reads scenes from structured `.json` files.
+- Each scene contains:
+  - A background image
+  - An ordered list of comic panels (images)
+  - Dialogue text per panel
+  - Optional branching choices with scene IDs
+
+### 2. JSON Scene Format Example
+
+```json
+{
+  "id": "scene1",
+  "background": "forest_day.png",
+  "panels": [
+    {
+      "image": "panel1.png",
+      "text": "You wake up in a dark forest."
+    },
+    {
+      "image": "panel2.png",
+      "text": "A path splits ahead. Which way will you go?",
+      "choices": [
+        { "text": "Left", "next": "scene2a" },
+        { "text": "Right", "next": "scene2b" }
+      ]
+    }
+  ]
+}
+```
+
+### 3. GDScript Goals
+
+* Load JSON files dynamically based on current scene.
+* Display background, then each panel image and its associated text.
+* Show user choices when present and wait for input.
+* Transition to the next scene based on user selection.
+
+### 4. Directories
+
+```
+/assets/images/      → comic panels and backgrounds
+/assets/audio/       → music and sound effects
+/scripts/            → GDScript files
+/data/scenes/        → JSON scene files
+```
+
+### 5. Functions the Agent May Implement
+
+* `load_scene(scene_id: String) -> void`
+* `show_panel(panel_data: Dictionary) -> void`
+* `display_choices(choices: Array) -> void`
+* `transition_to_scene(next_scene_id: String) -> void`
+* JSON schema validator or generator
+
+---
+
+## ✍️ Authoring Support
+
+Codex can also:
+
+* Auto-generate a new scene template given plain English description.
+* Refactor existing JSON or GDScript for readability or modularity.
+* Build visual tools for story designers.
+
+---
+
+## 💬 Behavior Expectations
+
+* Prioritize simplicity and clarity in code.
+* Use comments to explain logic, especially around user input and scene transitions.
+* Always validate JSON before loading scenes.
+* Reuse reusable UI components (e.g., panel display, choice buttons).
+
+---
+
+## ✅ Definition of Done
+
+* Panel images and dialogue are shown in order.
+* Choices appear only when defined in the JSON.
+* Selecting a choice correctly transitions to the next scene.
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,99 @@
-# Ava-Game
-Ava’s video game project
+# Comic Strip Story Game
+
+A comic-style, choose-your-own-adventure video game built with **Godot 4.x**. The game presents a narrative through a series of illustrated panels and dialogue, with branching paths based on player choices.
+
+---
+
+## 🎯 Features
+
+- Comic book layout with speech bubbles or panel captions
+- JSON-based narrative scripting (easy to edit or auto-generate)
+- Scene branching via player decisions
+- Modular and expandable structure
+- Designed to be easy for Codex/GPT assistance
+
+---
+
+## 📦 Directory Structure
+
+````
+
+/assets/images/      → Comic panel images and backgrounds
+/assets/audio/       → Background music and sound effects
+/scripts/            → All GDScript files
+/data/scenes/        → Narrative JSON files
+AGENTS.md            → Codex instructions for AI coding assistant
+README.md            → Project overview
+
+````
+
+---
+
+## 🧪 Requirements
+
+- [Godot 4.x](https://godotengine.org/)
+- Python (optional, for future tools or validators)
+- VS Code (recommended, with GitHub Copilot)
+
+---
+
+## 🚀 Getting Started
+
+1. Clone this repo.
+2. Open the project in Godot.
+3. Run `main.tscn` to start the game.
+4. Add or edit scenes in `/data/scenes/scene_id.json`.
+
+---
+
+## 🧠 Creating a New Scene
+
+Create a new JSON file like this:
+
+```json
+{
+  "id": "scene_new",
+  "background": "desert.png",
+  "panels": [
+    { "image": "panel1.png", "text": "You wander through the hot sand." },
+    {
+      "image": "panel2.png",
+      "text": "You spot something glinting ahead.",
+      "choices": [
+        { "text": "Investigate", "next": "scene_gold" },
+        { "text": "Ignore it", "next": "scene_ignore" }
+      ]
+    }
+  ]
+}
+```
+
+---
+
+## 🧑‍💻 Codex Integration
+
+This project is designed to work well with GitHub Copilot or GPT-based assistants. See `AGENTS.md` for AI guidance.
+
+---
+
+## 🛣️ Roadmap
+
+* [ ] Base game loop: load → show panel → wait for input
+* [ ] Scene transitions based on choices
+* [ ] Sound/music integration
+* [ ] UI polish (dialogue boxes, panel animations)
+* [ ] Save/load system
+* [ ] Export to PC and WebGL
+
+---
+
+## 📄 License
+
+MIT License – feel free to use or adapt.
+
+---
+
+## ✨ Contributors
+
+Created by Ava. AI-assisted by OpenAI Codex. 
+


### PR DESCRIPTION
## Summary
- expand README with project overview, directory layout, and scene template example
- add AGENTS.md detailing goals, architecture, and guidance for AI assistants

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f98cb9218832d9124def316f1f02d